### PR TITLE
25-02-27 문정현 | 생산계획조회 수정

### DIFF
--- a/src/main/java/com/org/qualitycore/productionPlan/controller/PlanController.java
+++ b/src/main/java/com/org/qualitycore/productionPlan/controller/PlanController.java
@@ -6,6 +6,7 @@ import com.org.qualitycore.productionPlan.model.dto.PlanMaterialDTO;
 import com.org.qualitycore.productionPlan.model.dto.ProductBomDTO;
 import com.org.qualitycore.productionPlan.model.dto.ProductionPlanDTO;
 import com.org.qualitycore.productionPlan.model.service.PlanService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpHeaders;
@@ -24,6 +25,7 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
+@Tag(name = "ProductionPlan",description = "생산계획 API_Controller")
 public class PlanController {
 
     /*
@@ -179,5 +181,8 @@ public class PlanController {
                     .body(new Message(500, "생산 계획 저장 중 오류 발생: " + e.getMessage(), Map.of()));
         }
     }
+
+    
+
 
 }

--- a/src/main/java/com/org/qualitycore/productionPlan/model/dto/ProductionPlanDTO.java
+++ b/src/main/java/com/org/qualitycore/productionPlan/model/dto/ProductionPlanDTO.java
@@ -27,6 +27,8 @@ public class ProductionPlanDTO {
     @JsonProperty("products")
     private List<ProductionPlanDTO> products;
     private MaterialRequestDTO materialRequests;
+    private List<PlanMaterialDTO> rawMaterials;
+    private List<PlanMaterialDTO> packagingMaterials;
 
 }
 

--- a/src/main/java/com/org/qualitycore/productionPlan/model/dto/ProductionPlanDTO.java
+++ b/src/main/java/com/org/qualitycore/productionPlan/model/dto/ProductionPlanDTO.java
@@ -29,6 +29,9 @@ public class ProductionPlanDTO {
     private MaterialRequestDTO materialRequests;
     private List<PlanMaterialDTO> rawMaterials;
     private List<PlanMaterialDTO> packagingMaterials;
+    private String mainProductName;
+    private Integer totalPlanQty;
+    private String planId;
 
 }
 

--- a/src/main/java/com/org/qualitycore/productionPlan/model/entity/PlanMaterial.java
+++ b/src/main/java/com/org/qualitycore/productionPlan/model/entity/PlanMaterial.java
@@ -46,7 +46,6 @@ public class PlanMaterial {
     @Column(name = "BEER_NAME")
     private String beerName;
 
-    @Column(name = "SHORTAGE_QTY")
-    private Double shortageQty;
+
 
 }

--- a/src/main/java/com/org/qualitycore/productionPlan/model/entity/PlanMst.java
+++ b/src/main/java/com/org/qualitycore/productionPlan/model/entity/PlanMst.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -38,6 +39,35 @@ public class PlanMst {
         if (this.createdBy == null) {
             this.createdBy = "SYSTEM";  // 기본값 설정
         }
+    }
+
+    // 연관관계 추가
+    @OneToMany(mappedBy = "planMst")
+    private List<PlanProduct> products = new ArrayList<>();
+
+    // 데이터베이스에 저장되지 않는 필드
+    @Transient
+    private String mainProductName;
+
+    @Transient
+    private Integer totalPlanQty;
+
+    // 첫 번째 제품의 이름 가져오기
+    public String getMainProductName() {
+        if (products != null && !products.isEmpty()) {
+            return products.get(0).getProductName();
+        }
+        return null;
+    }
+
+    // 모든 제품의 총 계획 수량 계산
+    public Integer getTotalPlanQty() {
+        if (products != null) {
+            return products.stream()
+                    .mapToInt(PlanProduct::getPlanQty)
+                    .sum();
+        }
+        return 0;
     }
 
 }

--- a/src/main/java/com/org/qualitycore/productionPlan/model/entity/PlanProduct.java
+++ b/src/main/java/com/org/qualitycore/productionPlan/model/entity/PlanProduct.java
@@ -31,6 +31,14 @@ public class PlanProduct{
     @Column(name = "PLAN_QTY", nullable = false)
     private Integer planQty;      //계획수량
 
-    @Column(name = "SIZE_SPEC") //
+    @Column(name = "SIZE_SPEC", nullable = false)
     private String sizeSpec;
+
+    @PrePersist
+    public void prePersist() {
+        if (this.sizeSpec == null) {
+            this.sizeSpec = "500ml";
+        }
+    }
 }
+

--- a/src/main/java/com/org/qualitycore/productionPlan/model/entity/ProductionPlan.java
+++ b/src/main/java/com/org/qualitycore/productionPlan/model/entity/ProductionPlan.java
@@ -16,7 +16,7 @@ import jakarta.persistence.Id;
 public class ProductionPlan {
 
 
-    // 이곳은 생산계획조회 DTO 입니다.
+//     이곳은 생산계획조회 DTO 입니다.
     @Id
     @Column(name = "PLAN_PRODUCT_ID")
     private String planProductId;     // 생산계획제품 ID
@@ -35,4 +35,11 @@ public class ProductionPlan {
 
     @Column(name = "PRODUCT_ID")
     private String productId;  // 제품 ID
+
+//    private String planProductId;
+//    private String planId;
+//    private String productName;
+//    private String sizeSpec;
+//    private Integer planQty;
+//    private String productId;
 }

--- a/src/main/java/com/org/qualitycore/productionPlan/model/repository/PlanRepository.java
+++ b/src/main/java/com/org/qualitycore/productionPlan/model/repository/PlanRepository.java
@@ -2,48 +2,98 @@ package com.org.qualitycore.productionPlan.model.repository;
 
 import com.org.qualitycore.productionPlan.model.dto.ProductionPlanDTO;
 import com.org.qualitycore.productionPlan.model.entity.QPlanMst;
+
+import com.org.qualitycore.productionPlan.model.entity.QPlanProduct;
+
 import com.org.qualitycore.productionPlan.model.entity.QProductionPlan;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
 public class PlanRepository {
 
     private final JPAQueryFactory queryFactory;
-
     public List<ProductionPlanDTO> findProductionPlans(LocalDate startDate, LocalDate endDate, String status) {
         QPlanMst planMst = QPlanMst.planMst;
         QProductionPlan productionPlan = QProductionPlan.productionPlan;
 
         BooleanBuilder whereClause = new BooleanBuilder();
-        whereClause.and(planMst.planYm.between(startDate, endDate)); // LocalDate 비교
+        whereClause.and(planMst.planYm.between(startDate, endDate));
 
-        // status 필터링 (null 체크 개선)
         if (status != null && !status.isBlank()) {
             whereClause.and(planMst.status.eq(status));
         }
 
-        return queryFactory
-                .select(Projections.fields(ProductionPlanDTO.class,
-                        planMst.planYm.as("planYm"), // LocalDate 그대로 사용
-                        productionPlan.productId.as("productId"),
-                        productionPlan.productName.as("productName"),
-                        productionPlan.sizeSpec.as("sizeSpec"),
-                        productionPlan.planQty.as("planQty"),
-                        planMst.status.as("status")
-                ))
-                .from(productionPlan)
-                .join(planMst).on(productionPlan.planId.eq(planMst.planId))
+        // 서브쿼리를 별도로 추출
+        List<Tuple> results = queryFactory
+                .select(
+                        planMst.planId,
+                        planMst.planYm,
+
+                        // ✅ 대표 제품명 (최소 제품명)
+                        productionPlan.productName.min(),
+
+                        // ✅ Oracle에서 모든 `sizeSpec`을 하나의 문자열로 합쳐서 가져옴 (중복 제거)
+                        Expressions.stringTemplate(
+                                "LISTAGG(DISTINCT {0}, ', ') WITHIN GROUP (ORDER BY {0})", productionPlan.sizeSpec
+                        ),
+
+                        // ✅ 총 계획 수량
+                        productionPlan.planQty.sum(),
+
+                        planMst.status,
+
+                        // ✅ 제품 개수
+                        Expressions.stringTemplate(
+                                "COUNT(DISTINCT {0})", productionPlan.productName
+                        )
+                )
+                .from(planMst)
+                .leftJoin(productionPlan).on(productionPlan.planId.eq(planMst.planId))
                 .where(whereClause)
+                .groupBy(planMst.planId, planMst.planYm, planMst.status)
                 .fetch();
+
+        // 결과 변환
+        return results.stream()
+                .map(tuple -> {
+                    ProductionPlanDTO dto = new ProductionPlanDTO();
+                    dto.setPlanId(tuple.get(0, String.class));
+                    dto.setPlanYm(tuple.get(1, LocalDate.class));
+
+                    // 대표 제품명 생성
+                    String productName = tuple.get(2, String.class);
+                    Long productCount = tuple.get(6, Long.class);
+                    dto.setMainProductName(
+                            productCount > 1
+                                    ? productName + " 외 " + (productCount - 1) + "개"
+                                    : productName
+                    );
+
+                    // ✅ `sizeSpec`을 하나의 문자열로 저장
+                    dto.setSizeSpec(tuple.get(3, String.class));
+
+                    dto.setTotalPlanQty(tuple.get(4, Integer.class));
+                    dto.setStatus(tuple.get(5, String.class));
+
+                    return dto;
+                })
+                .collect(Collectors.toList());
     }
+
+
+
+
 }

--- a/src/main/java/com/org/qualitycore/productionPlan/model/service/PlanService.java
+++ b/src/main/java/com/org/qualitycore/productionPlan/model/service/PlanService.java
@@ -357,7 +357,7 @@ public class PlanService {
         if (completeProductionPlan.getProducts() != null && !completeProductionPlan.getProducts().isEmpty()) {
             System.out.println("🔍 Step 3: 자재 저장 시작");
 
-            // 제품 리스트를 순회하면서 자재 정보 생성
+            // 기존 레시피 기반 자재 저장 로직
             for (ProductionPlanDTO productDTO : completeProductionPlan.getProducts()) {
                 String productId = productDTO.getProductId();
                 String productName = productDTO.getProductName();
@@ -397,16 +397,111 @@ public class PlanService {
                     planMaterial.setCurrentStock(material.getCurrentStock());
                     planMaterial.setBeerName(productName);
 
-                    // 상태 및 부족 수량 결정
+                    // 상태 결정
                     if (totalQuantity > material.getCurrentStock()) {
                         planMaterial.setStatus("부족");
-                        planMaterial.setShortageQty(totalQuantity - material.getCurrentStock());
                     } else {
                         planMaterial.setStatus("충분");
-                        planMaterial.setShortageQty(0.0);
                     }
 
-                    System.out.println("✅ 저장될 자재 정보: " + planMaterial);
+                    System.out.println("✅ 저장될 레시피 기반 자재 정보: " + planMaterial);
+
+                    planMaterialRepository.save(planMaterial);
+                    entityManager.flush();
+                }
+            }
+
+            // 원자재(Raw Materials) 저장 로직
+            if (completeProductionPlan.getRawMaterials() != null && !completeProductionPlan.getRawMaterials().isEmpty()) {
+                System.out.println("🔍 원자재 저장 시작");
+                for (PlanMaterialDTO materialDTO : completeProductionPlan.getRawMaterials()) {
+                    // 맥주 이름으로 제품 찾기
+                    ProductionPlanDTO relatedProduct = completeProductionPlan.getProducts().stream()
+                            .filter(p -> p.getProductName().equals(materialDTO.getBeerName()))
+                            .findFirst()
+                            .orElse(null);
+
+                    if (relatedProduct == null) {
+                        System.out.println("🚨 경고: " + materialDTO.getBeerName() + "에 해당하는 제품 정보 없음");
+                        continue;
+                    }
+
+                    String productId = relatedProduct.getProductId();
+                    String relatedPlanProductId = productPlanIdMap.get(productId);
+
+                    if (relatedPlanProductId == null) {
+                        System.out.println("🚨 경고: " + productId + "에 해당하는 PLAN_PRODUCT_ID 없음");
+                        continue;
+                    }
+
+                    PlanMaterial planMaterial = new PlanMaterial();
+                    planMaterial.setPlanMaterialId(generateNewPlanMaterialId());
+
+                    PlanProduct planProduct = new PlanProduct();
+                    planProduct.setPlanProductId(relatedPlanProductId);
+                    planProduct.setProductId(productId);
+
+                    planMaterial.setPlanProduct(planProduct);
+                    planMaterial.setMaterialId(materialDTO.getMaterialId());
+                    planMaterial.setMaterialName(materialDTO.getMaterialName());
+                    planMaterial.setMaterialType(materialDTO.getMaterialType());
+                    planMaterial.setUnit(materialDTO.getUnit());
+                    planMaterial.setStdQty(materialDTO.getStdQty());
+                    planMaterial.setPlanQty(materialDTO.getPlanQty());
+                    planMaterial.setCurrentStock(materialDTO.getCurrentStock());
+                    planMaterial.setBeerName(materialDTO.getBeerName());
+                    planMaterial.setStatus(materialDTO.getStatus());
+
+
+                    System.out.println("✅ 저장될 원자재 정보: " + planMaterial);
+
+                    planMaterialRepository.save(planMaterial);
+                    entityManager.flush();
+                }
+            }
+
+            // 포장재(Packaging Materials) 저장 로직
+            if (completeProductionPlan.getPackagingMaterials() != null && !completeProductionPlan.getPackagingMaterials().isEmpty()) {
+                System.out.println("🔍 포장재 저장 시작");
+                for (PlanMaterialDTO materialDTO : completeProductionPlan.getPackagingMaterials()) {
+                    // 맥주 이름으로 제품 찾기
+                    ProductionPlanDTO relatedProduct = completeProductionPlan.getProducts().stream()
+                            .filter(p -> p.getProductName().equals(materialDTO.getBeerName()))
+                            .findFirst()
+                            .orElse(null);
+
+                    if (relatedProduct == null) {
+                        System.out.println("🚨 경고: " + materialDTO.getBeerName() + "에 해당하는 제품 정보 없음");
+                        continue;
+                    }
+
+                    String productId = relatedProduct.getProductId();
+                    String relatedPlanProductId = productPlanIdMap.get(productId);
+
+                    if (relatedPlanProductId == null) {
+                        System.out.println("🚨 경고: " + productId + "에 해당하는 PLAN_PRODUCT_ID 없음");
+                        continue;
+                    }
+
+                    PlanMaterial planMaterial = new PlanMaterial();
+                    planMaterial.setPlanMaterialId(generateNewPlanMaterialId());
+
+                    PlanProduct planProduct = new PlanProduct();
+                    planProduct.setPlanProductId(relatedPlanProductId);
+                    planProduct.setProductId(productId);
+
+                    planMaterial.setPlanProduct(planProduct);
+                    planMaterial.setMaterialId(materialDTO.getMaterialId());
+                    planMaterial.setMaterialName(materialDTO.getMaterialName());
+                    planMaterial.setMaterialType(materialDTO.getMaterialType());
+                    planMaterial.setUnit(materialDTO.getUnit());
+                    planMaterial.setStdQty(materialDTO.getStdQty());
+                    planMaterial.setPlanQty(materialDTO.getPlanQty());
+                    planMaterial.setCurrentStock(materialDTO.getCurrentStock());
+                    planMaterial.setBeerName(materialDTO.getBeerName());
+                    planMaterial.setStatus(materialDTO.getStatus());
+
+                    System.out.println("✅ 저장될 포장재 정보: " + planMaterial);
 
                     planMaterialRepository.save(planMaterial);
                     entityManager.flush();
@@ -427,42 +522,47 @@ public class PlanService {
             if (requestDTO.getMaterials() != null && !requestDTO.getMaterials().isEmpty()) {
                 for (MaterialRequestDTO.MaterialRequestInfo materialRequestInfo : requestDTO.getMaterials()) {
                     // null 체크 추가
-                    if (materialRequestInfo.getMaterialId() == null ||
-                            materialRequestInfo.getProductId() == null) {
-                        System.out.println("🚨 경고: materialId 또는 productId가 null입니다.");
+                    if (materialRequestInfo.getMaterialId() == null) {
+                        System.out.println("🚨 경고: materialId가 null입니다.");
                         continue; // 다음 반복으로 건너뜀
                     }
 
-                    // 해당 자재의 PlanMaterial 찾기
-                    Optional<PlanMaterial> planMaterialOpt = planMaterialRepository
-                            .findByMaterialIdAndPlanProduct_PlanProductId(
-                                    materialRequestInfo.getMaterialId(),
-                                    productPlanIdMap.get(materialRequestInfo.getProductId())
-                            );
+                    // 모든 PlanProduct에 대해 반복하며 PlanMaterial 찾기
+                    boolean materialFound = false;
+                    for (String planProductId : productPlanIdMap.values()) {
+                        Optional<PlanMaterial> planMaterialOpt = planMaterialRepository
+                                .findByMaterialIdAndPlanProduct_PlanProductId(
+                                        materialRequestInfo.getMaterialId(),
+                                        planProductId
+                                );
 
-                    // Optional 체크 추가
-                    if (planMaterialOpt.isEmpty()) {
-                        System.out.println("🚨 경고: 해당 자재의 생산 계획 정보를 찾을 수 없습니다.");
-                        continue; // 다음 반복으로 건너뜀
+                        if (planMaterialOpt.isPresent()) {
+                            PlanMaterial planMaterial = planMaterialOpt.get();
+
+                            MaterialRequest materialRequest = new MaterialRequest();
+                            materialRequest.setRequestId(generateNewMaterialRequestId());
+                            materialRequest.setPlanMaterial(planMaterial);
+                            materialRequest.setRequestQty(materialRequestInfo.getRequestQty());
+                            materialRequest.setDeliveryDate(requestDTO.getDeliveryDate());
+                            materialRequest.setReason(requestDTO.getReason());
+                            materialRequest.setNote(requestDTO.getNote());
+
+                            // 로깅 추가
+                            System.out.println("🚀 자재 요청 정보 저장: " +
+                                    "RequestId: " + materialRequest.getRequestId() +
+                                    ", MaterialId: " + materialRequestInfo.getMaterialId() +
+                                    ", RequestQty: " + materialRequest.getRequestQty() +
+                                    ", PlanProductId: " + planProductId);
+
+                            materialRequestRepository.save(materialRequest);
+                            materialFound = true;
+                            break;
+                        }
                     }
 
-                    PlanMaterial planMaterial = planMaterialOpt.get();
-
-                    MaterialRequest materialRequest = new MaterialRequest();
-                    materialRequest.setRequestId(generateNewMaterialRequestId());
-                    materialRequest.setPlanMaterial(planMaterial);
-                    materialRequest.setRequestQty(materialRequestInfo.getRequestQty());
-                    materialRequest.setDeliveryDate(requestDTO.getDeliveryDate());
-                    materialRequest.setReason(requestDTO.getReason());
-                    materialRequest.setNote(requestDTO.getNote());
-
-                    // 로깅 추가
-                    System.out.println("🚀 자재 요청 정보 저장: " +
-                            "RequestId: " + materialRequest.getRequestId() +
-                            ", MaterialId: " + materialRequestInfo.getMaterialId() +
-                            ", RequestQty: " + materialRequest.getRequestQty());
-
-                    materialRequestRepository.save(materialRequest);
+                    if (!materialFound) {
+                        System.out.println("🚨 경고: 해당 자재의 생산 계획 정보를 찾을 수 없습니다. MaterialId: " + materialRequestInfo.getMaterialId());
+                    }
                 }
 
                 System.out.println("✅ 자재 요청 저장 완료");


### PR DESCRIPTION
## #️⃣ Issue Number

#103 

## 📝 요약(Summary)

- 생산계획조회했을시 제품이 여러개이면 제품갯수만큼 하나의 생산계획인데도 여러행이 조회됨 
  본인은 1개의 생산계획이면  1개의행으로 조회가되길 원해서 제품명을 예시: 아이유맥주외 2개 이런식으로 수정하여 
 1개의 행으로 출력되게 업그레이드함

# 💻 백엔드

## 🧐 기능 및 API  
- [ ] 새 API 추가
- [x] 기존 API 수정
- [ ] API의 엔드포인트(`URL`) 수정
- [x] 데이터베이스 구조 변경 (엔티티, 테이블, 컬럼 수정)
- [ ] API 응답 구조 변경 (`ResponseMessage` 필드명, 데이터 구조 수정)

## 🤯 보안 및 성능      
- [ ] 성능 개선 (쿼리 최적화, 캐싱)  
- [ ] 보안 관련 수정 (인증/인가, 데이터 검증)
- [ ] 예외 처리 개선 (예외 핸들링 로직 추가/수정)

## 😈 버그  
- [ ] 버그 수정

## 😘 기타  
- [ ] API 문서화 (`Swagger` 설정 추가/수정)
- [ ] 주석 추가 및 수정  
- [ ] 코드 리팩토링 (파일/폴더명 변경, 코드 스타일 정리)
- [ ] 불필요한 코드 및 파일 삭제  
- [ ] 테스트  

## 📸스크린샷 (되도록 넣어주세요!!)
![생산계획조회 외n개](https://github.com/user-attachments/assets/ee6878e5-e916-4606-8914-e0209fb9716b)




## ✅ PR Checklist
PR 에 대해 확인 하였으면 본인 이름을 체크해주세요. 
<br>
📢 문정현 형상관리자님 MERGE 잘부탁드려요

- [x] 이승현(PM)
- [x] 문정현(형상관리자)
- [ ] 김남규(DB)
- [ ] 김관훈(DB)
