### PR TITLE
25-03-05 김남규 | 분쇄공정 등록 수정 파이널!!!

### DIFF
--- a/src/main/java/com/org/qualitycore/standardinformation/controller/MaterialGrindingController.java
+++ b/src/main/java/com/org/qualitycore/standardinformation/controller/MaterialGrindingController.java
@@ -35,95 +35,100 @@ public class MaterialGrindingController {
 
 
 
+
         // ✅ 작업지시 ID 목록 조회
-        @Operation(summary = "작업지시 ID 목록 조회", description = "현재 등록된 작업지시 ID 목록을 조회합니다.")
-            @ApiResponses(value = {
-                @ApiResponse(responseCode = "200", description = "조회 성공"),
-                @ApiResponse(responseCode = "500", description = "서버 내부 오류")
-            })
-        @GetMapping("/linematerial")
-        public ResponseEntity<Message> getLineMaterial() {
-            log.info("컨트롤러: 작업지시 ID 목록 조회 요청");
-            List<LineMaterialNDTO> lineMaterials = materialGrindingService.getLineMaterial();
-            Message response;
-            if (lineMaterials.isEmpty()) {
-                response = new Message(500, "서버 내부 오류", new HashMap<>());
-            } else {
-                response = new Message(200, "조회 성공", new HashMap<>());
-                response.getResult().put("lineMaterials", lineMaterials);
-            }
-            return ResponseEntity.status(response.getCode()).body(response);
+    @Operation(summary = "작업지시 ID 목록 조회", description = "현재 등록된 작업지시 ID 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @GetMapping("/linematerial")
+    public ResponseEntity<Message> getLineMaterial() {
+        log.info("컨트롤러: 작업지시 ID 목록 조회 요청");
+        List<LineMaterialNDTO> lineMaterials = materialGrindingService.getLineMaterial();
+        Message response;
+        if (lineMaterials.isEmpty()) {
+            response = new Message(500, "서버 내부 오류", new HashMap<>());
+        } else {
+            response = new Message(200, "조회 성공", new HashMap<>());
+            response.getResult().put("lineMaterials", lineMaterials);
         }
+        return ResponseEntity.status(response.getCode()).body(response);
+    }
 
 
-        // ✅ 특정 LOT_NO에 대한 자재 정보 조회
-        @Operation(summary = "LOT_NO에 따른 자재 정보 조회", description = "특정 작업지시 ID(LOT_NO)에 대한 자재 정보를 조회합니다.")
-            @ApiResponses(value = {
-                @ApiResponse(responseCode = "200", description = "조회 성공"),
-                @ApiResponse(responseCode = "404", description = "데이터 없음")
-            })
-        @GetMapping("/{lotNo}")
-        public ResponseEntity<Message> getMaterialsByLotNo(@PathVariable String lotNo) {
-            log.info("컨트롤러: LOT_NO={}에 대한 자재 정보 요청", lotNo);
-            List<LineMaterialNDTO> materials = materialGrindingService.getMaterialsByLotNo(lotNo);
-            Message response;
-            if (materials.isEmpty()) {
-                response = new Message(404, "데이터 없음", new HashMap<>());
-            } else {
-                response = new Message(200, "조회 성공", new HashMap<>());
-                response.getResult().put("materials", materials);
-            }
-            return ResponseEntity.status(response.getCode()).body(response);
+
+    // ✅ 특정 LOT_NO에 대한 자재 정보 조회
+    @Operation(summary = "LOT_NO에 따른 자재 정보 조회", description = "특정 작업지시 ID(LOT_NO)에 대한 자재 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "데이터 없음")
+    })
+    @GetMapping("/{lotNo}")
+    public ResponseEntity<Message> getMaterialsByLotNo(@PathVariable String lotNo) {
+        log.info("컨트롤러: LOT_NO={}에 대한 자재 정보 요청", lotNo);
+        List<LineMaterialNDTO> materials = materialGrindingService.getMaterialsByLotNo(lotNo);
+        Message response;
+        if (materials.isEmpty()) {
+            response = new Message(404, "데이터 없음", new HashMap<>());
+        } else {
+            response = new Message(200, "조회 성공", new HashMap<>());
+            response.getResult().put("materials", materials);
         }
+        return ResponseEntity.status(response.getCode()).body(response);
+    }
 
 
 
 
-        //✅ 분쇄공정 등록
-        @Operation(summary = "분쇄공정" ,description = "분쇄공정 작업을 등록합니다.")
-            @ApiResponses(value = {
-                @ApiResponse(responseCode = "201" , description = "등록에 성공!"),
-                @ApiResponse(responseCode = "400" , description = "잘못된 요청입니다!")
-        })
 
-        @PostMapping("/materialgrinding")
-        public ResponseEntity<Message> createMaterialGrinding(
+
+    //✅ 분쇄공정 등록
+    @Operation(summary = "분쇄공정" ,description = "분쇄공정 작업을 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201" , description = "등록에 성공!"),
+            @ApiResponse(responseCode = "400" , description = "잘못된 요청입니다!")
+    })
+    @PostMapping("/materialgrinding")
+    public ResponseEntity<Message> createMaterialGrinding(
             @RequestBody @Parameter(description = "등록할 분쇄 정보" ,
                     required = true) MaterialGrindingDTO materialGrindingDTO){
-            log.info("컨트롤러 : 분쇄공정 등록 요청 {} " ,materialGrindingDTO);
+        log.info("컨트롤러 : 분쇄공정 등록 요청 {} " ,materialGrindingDTO);
+        Message response = materialGrindingService.createMaterialGrinding(materialGrindingDTO);
+        return ResponseEntity.status(response.getCode()).body(response);
+    }
 
-            Message response = materialGrindingService.createMaterialGrinding(materialGrindingDTO);
-            return ResponseEntity.status(response.getCode()).body(response);
-        }
 
 
-        // 실제 종료시간을  위해서 수정 추가 구현
-        @PutMapping("/materialgrinding/{grindingId}")
-        public ResponseEntity<MaterialGrindingDTO> completeEndTime(
-                @PathVariable String grindingId) {
+    // 실제 종료시간을  위해서 수정 추가 구현
+    @PutMapping("/materialgrinding/{grindingId}")
+    public ResponseEntity<MaterialGrindingDTO> completeEndTime(
+            @PathVariable String grindingId) {
             log.info("컨트롤러 : 분쇄 공정 완료 요청 - ID: {}", grindingId);
             MaterialGrindingDTO updatedGrinding = materialGrindingService.completeEndTime(grindingId);
             return ResponseEntity.ok(updatedGrinding);
         }
 
 
-        @PutMapping("/start/{grindingId}")
-        public ResponseEntity<MaterialGrindingDTO> startGrinding(
-                @PathVariable String grindingId) {
-            log.info("▶ 분쇄 공정 시작 요청 - ID: {}", grindingId);
-            MaterialGrindingDTO updatedGrinding = materialGrindingService.startGrindingProcess(grindingId);
-            return ResponseEntity.ok(updatedGrinding);
-        }
+
+        // ✅ 특정 LOT_NO에 대한 분쇄 공정 상태 업데이트
+    @Operation(summary = "LOT_NO에 따른 공정 상태 업데이트", description = "LOT_NO를 기준으로 공정 상태를 업데이트합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "업데이트 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @ApiResponse(responseCode = "404", description = "해당 LOT_NO 없음")
+    })
+    @PutMapping("/update")
+    public ResponseEntity<Message> updateMaterialGrinding(@RequestBody MaterialGrindingDTO materialGrindingDTO) {
+        log.info("컨트롤러: LOT_NO={} 공정 상태 업데이트 요청", materialGrindingDTO.getLotNo());
+        Message response = materialGrindingService.updateMaterialGrinding(materialGrindingDTO);
+        return ResponseEntity.status(response.getCode()).body(response);
+    }
 
 
-
-        @PutMapping("/complete/{grindingId}")
-        public ResponseEntity<MaterialGrindingDTO> completeGrinding(
-                @PathVariable String grindingId) {
-            log.info("▶ 분쇄 공정 완료 요청 - ID: {}", grindingId);
-            MaterialGrindingDTO updatedGrinding = materialGrindingService.completeGrindingProcess(grindingId);
-            return ResponseEntity.ok(updatedGrinding);
-        }
 
 
 }
+
+
+

--- a/src/main/java/com/org/qualitycore/standardinformation/model/dto/MaterialGrindingDTO.java
+++ b/src/main/java/com/org/qualitycore/standardinformation/model/dto/MaterialGrindingDTO.java
@@ -1,5 +1,6 @@
 package com.org.qualitycore.standardinformation.model.dto;
 
+import com.org.qualitycore.routing.model.dto.ProcessTrackingDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -19,9 +20,6 @@ public class MaterialGrindingDTO {
 
     @Schema(description = "작업지시 ID" , example ="LOT2025021301")
     private String lotNo;
-
-    @Schema(description = "상태 코드 ID", example = "SC001")
-    private String statusCode;
 
     @Schema(description = "주원료" , example ="쌀")
     private String mainMaterial;
@@ -44,12 +42,6 @@ public class MaterialGrindingDTO {
     @Schema(description = "소요시간" , example = "40")
     private Integer grindDuration;
 
-    @Schema(description = "공정 상태", example = "대기중")
-    private String processStatus;
-
-    @Schema(description = "공정 이름", example = "분쇄")
-    private String processName;
-
     @Schema(description = "메모사항" , example = "작업자 : 강동원 작업완료")
     private String notes;
 
@@ -61,4 +53,9 @@ public class MaterialGrindingDTO {
 
     @Schema(description = "실제 종료 시간" , example = "2025-02-12T11:00:30")
     private LocalDateTime actualEndTime;
+
+    @Schema(description = "공정 추적 DTO" )
+    private ProcessTrackingDTONam processTracking;
+
+
 }

--- a/src/main/java/com/org/qualitycore/standardinformation/model/dto/ProcessTrackingDTONam.java
+++ b/src/main/java/com/org/qualitycore/standardinformation/model/dto/ProcessTrackingDTONam.java
@@ -1,0 +1,31 @@
+package com.org.qualitycore.standardinformation.model.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "공정 추적 DTO")
+public class ProcessTrackingDTONam {
+
+    @Schema(description = "공정 추적 ID", example = "1")
+    private Long trackingId;
+
+    @Schema(description = "작업지시 ID" , example = "LOT2025021201")
+    private String lotNo;  // workOrders 대신 lotNo만 포함
+
+    @Schema(description = "상태 코드 ID", example = "SC001")
+    private String statusCode;
+
+    @Schema(description = "공정 상태", example = "대기 중")
+    private String processStatus;
+
+    @Schema(description = "공정 이름", example = "분쇄")
+    private String processName;
+
+}

--- a/src/main/java/com/org/qualitycore/standardinformation/model/entity/MaterialGrinding.java
+++ b/src/main/java/com/org/qualitycore/standardinformation/model/entity/MaterialGrinding.java
@@ -1,7 +1,7 @@
 package com.org.qualitycore.standardinformation.model.entity;
 
+import com.org.qualitycore.work.model.entity.processTracking;
 import com.org.qualitycore.work.model.entity.LineMaterial;
-import com.org.qualitycore.work.model.entity.WorkOrders;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.*;
@@ -34,9 +34,9 @@ public class MaterialGrinding {
     @Schema(description = "작업지시 ID" , example ="LOT2025021301")
     private List<LineMaterial> lineMaterials;
 
-    @Column(name ="STATUS_CODE" , nullable = false , updatable = false )
-    @Schema(description = "상태 코드 ID", example = "SC001")
-    private String statusCode;
+    @ManyToOne(fetch = FetchType.LAZY )
+    @Schema(description = "공정상태 체크" )
+    private processTracking processTracking;
 
     @Column(name ="MAIN_MATERIAL" , nullable = false )
     @Schema(description = "주원료" , example ="쌀")
@@ -67,13 +67,6 @@ public class MaterialGrinding {
     @Schema(description = "소요시간 " , example = "40" )
     private Integer grindDuration;
 
-    @Column(name = "PROCESS_STATUS", nullable = false)
-    @Schema(description = "공정 상태", example = "대기중")
-    private String processStatus="대기중";
-
-    @Column(name = "PROCESS_NAME", nullable = false)
-    @Schema(description = "공정 이름", example = "분쇄")
-    private String processName = "분쇄";
 
     @Column(name = "NOTES")
     @Schema(description = "메모사항" , example = "작업자 : 강동원  작업완료" )
@@ -114,15 +107,7 @@ public class MaterialGrinding {
             expectedEndTime = startTime.plusMinutes(grindDuration);
         }
 
-        // 공정 상태 기본값 설정
-        if (processStatus == null) {
-            processStatus = "대기중";
-        }
 
-        // 상태 코드 기본값 설정
-        if (statusCode == null) {
-            statusCode = "SC001";
-        }
     }
 
     @Override
@@ -131,7 +116,6 @@ public class MaterialGrinding {
                 "grindingId='" + grindingId + '\'' +
                 ", lotNo='" + lotNo + '\'' +
                 ", lineMaterials=" + lineMaterials +
-                ", statusCode='" + statusCode + '\'' +
                 ", mainMaterial='" + mainMaterial + '\'' +
                 ", mainMaterialInputVolume=" + mainMaterialInputVolume +
                 ", maltType='" + maltType + '\'' +
@@ -139,7 +123,6 @@ public class MaterialGrinding {
                 ", grindIntervalSetting=" + grindIntervalSetting +
                 ", grindSpeedSetting=" + grindSpeedSetting +
                 ", grindDuration=" + grindDuration +
-                ", processStatus='" + processStatus + '\'' +
                 ", notes='" + notes + '\'' +
                 ", startTime=" + startTime +
                 ", expectedEndTime=" + expectedEndTime +

--- a/src/main/java/com/org/qualitycore/work/model/entity/processTracking.java
+++ b/src/main/java/com/org/qualitycore/work/model/entity/processTracking.java
@@ -7,7 +7,7 @@ import lombok.*;
 @AllArgsConstructor
 @Getter
 @Setter
-@ToString
+
 @Entity
 @Table(name = "PROCESS_TRACKING")
 public class processTracking {
@@ -41,6 +41,18 @@ public class processTracking {
         if (this.processName == null) {
             this.processName = "분쇄 및 원재료투입";  // ✅ 기본값 예: '공정 미정'
         }
+    }
+
+
+    // 남규 ToString WorkOrders 제거함
+    @Override
+    public String toString() {
+        return "processTracking{" +
+                "trackingId=" + trackingId +
+                ", statusCode='" + statusCode + '\'' +
+                ", processStatus='" + processStatus + '\'' +
+                ", processName='" + processName + '\'' +
+                '}';
     }
 }
 

--- a/src/main/java/com/org/qualitycore/work/model/repository/ProcessTrackingRepository.java
+++ b/src/main/java/com/org/qualitycore/work/model/repository/ProcessTrackingRepository.java
@@ -1,8 +1,15 @@
 package com.org.qualitycore.work.model.repository;
 
+
 import com.org.qualitycore.work.model.entity.processTracking;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ProcessTrackingRepository extends JpaRepository<processTracking, Long> { }
+public interface ProcessTrackingRepository extends JpaRepository<processTracking, Long> {
+
+    // 남규 공정에서 잘쓰겠습니다 ㅋ
+    @Query("SELECT p FROM processTracking p WHERE p.workOrders.lotNo = :lotNo")
+    processTracking findByLotNo(String lotNo);
+}


### PR DESCRIPTION
## #️⃣ Issue Number



## 📝 요약(Summary)
MaterialGrinding 엔티티 등록시 LineMaterial 엔티티 안에 컬럼 가져올수 있게 설정
MaterialGrinding 엔티티 등록시processTracking 엔티티 로 데이터 보낼수있게 설정(가저와 볼수도있게 저장)

processTracking 수정시   MaterialGrinding  상황 데이터를 보내서 업데이트 할수 있게 설정




# 💻 백엔드

## 🧐 기능 및 API  
- [x] 새 API 추가
- [x] 기존 API 수정
- [ ] API의 엔드포인트(`URL`) 수정
- [ ] 데이터베이스 구조 변경 (엔티티, 테이블, 컬럼 수정)
- [x] API 응답 구조 변경 (`ResponseMessage` 필드명, 데이터 구조 수정)

## 🤯 보안 및 성능      
- [x] 성능 개선 (쿼리 최적화, 캐싱)  
- [ ] 보안 관련 수정 (인증/인가, 데이터 검증)
- [ ] 예외 처리 개선 (예외 핸들링 로직 추가/수정)

## 😈 버그  
- [ ] 버그 수정

## 😘 기타  
- [x] API 문서화 (`Swagger` 설정 추가/수정)
- [x] 주석 추가 및 수정  
- [ ] 코드 리팩토링 (파일/폴더명 변경, 코드 스타일 정리)
- [ ] 불필요한 코드 및 파일 삭제  
- [ ] 테스트  

## 📸스크린샷 (되도록 넣어주세요!!)
분쇄공정 등록
![등록](https://github.com/user-attachments/assets/5c7e3277-df01-4453-bc29-108e2f1c4b62)
분쇄공정 공정현황 processTracking 엔티티 수정 완료
![수정](https://github.com/user-attachments/assets/7e173185-53a2-42cc-a452-1694a754809b)
![수정증거1](https://github.com/user-attachments/assets/0768994a-4b8c-4af2-abca-675414e6f289)

분쇄 등록 서비스(컨트롤러 생략)
![분쇄등록 서비스](https://github.com/user-attachments/assets/f78ce026-78b8-470d-b064-362605a5fbc2)
분쇄공정 상태 수정 서비스 (컨트롤러 생략)
![분쇄공정상태 수정 서비스](https://github.com/user-attachments/assets/e5547323-9ad0-4d8f-9899-0df38833ac3d)

## ✅ PR Checklist
PR 에 대해 확인 하였으면 본인 이름을 체크해주세요. 
<br>
📢 문정현 형상관리자님 MERGE 잘부탁드려요

- [ ] 이승현(PM)
- [ ] 문정현(형상관리자)
- [x] 김남규(DB)
- [ ] 김관훈(DB)
